### PR TITLE
#159726622 Make activation url a one time link.

### DIFF
--- a/diary/exceptions.py
+++ b/diary/exceptions.py
@@ -1,0 +1,8 @@
+from rest_framework.exceptions import APIException
+
+
+class EmailNotSentException(APIException):
+    """ Exception thrown when the confirmation email can not be sent """
+    status_code = 503
+    default_detail = 'Service temporarily unavailable, try again later.'
+    default_code = 'not_registered'

--- a/diary/helpers.py
+++ b/diary/helpers.py
@@ -2,19 +2,13 @@ from django.core.mail import EmailMultiAlternatives
 from django.urls import reverse
 from django.template.loader import render_to_string
 from django.conf import settings
-from rest_framework.exceptions import APIException
-
-
-class EmailNotSentException(APIException):
-    """ Exception thrown when the confirmation email can not be sent """
-    status_code = 503
-    default_detail = 'Service temporarily unavailable, try again later.'
-    default_code = 'not_registered'
+from .tokens import ACTIVATIONTOKEN
 
 
 def send_email(user):
-    path = reverse('diary:activate')
-    activation_url = "{}{}?token={}".format(settings.SITE_ROOT, path, user.slug_field)
+    path = reverse('diary:activate', kwargs={'slug_field': user.slug_field})
+    token = ACTIVATIONTOKEN.make_token(user)
+    activation_url = "{}{}?token={}".format(settings.SITE_ROOT, path, token)
     html_message = render_to_string(
         'diary/activate.html',
         {

--- a/diary/serializers.py
+++ b/diary/serializers.py
@@ -1,7 +1,8 @@
 from smtplib import SMTPException
 from rest_framework import serializers
 from django.utils.text import slugify
-from .helpers import send_email, EmailNotSentException
+from .helpers import send_email
+from .exceptions import EmailNotSentException
 from .models import User
 
 

--- a/diary/tests/test_user_views.py
+++ b/diary/tests/test_user_views.py
@@ -60,11 +60,21 @@ class UserAccountActivationTestCase(TransactionTestCase):
 
     def test_user_account_activation(self):
         self.client.post(reverse('diary:signup'), data=self.user)
-        user = User.objects.get(pk=1)
-        self.client.get(reverse('diary:activate'), {'token': user.slug_field})
+        activation_url = mail.outbox[0].body.split(' ')[-1]
+        self.client.get(activation_url)
         active_user = User.objects.get(pk=1)
         self.assertTrue(active_user.is_active)
 
+    def test_user_account_activation_link_is_one_time(self):
+        self.client.post(reverse('diary:signup'), data=self.user)
+        activation_url = mail.outbox[0].body.split(' ')[-1]
+        self.client.get(activation_url)
+        response = self.client.get(activation_url)
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
     def test_user_account_activation_with_invalid_token(self):
-        response = self.client.get(reverse('diary:activate'), {'token': 'hjhgedgvgdgwegghegvghv'})
+        response = self.client.get(
+            reverse('diary:activate', kwargs={'slug_field': 'jkdjjdddhjjh'}),
+            {'token': 'hjhgedgvgdgwegghegvghv'}
+            )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/diary/tokens.py
+++ b/diary/tokens.py
@@ -1,0 +1,10 @@
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
+
+
+class AccountActivationToken(PasswordResetTokenGenerator):
+    """ Generate a one time login token with the user's slug_field, state and timestamp."""
+    def _make_hash_value(self, user, timestamp):
+        return str(user.slug_field) + str(user.is_active) + str(timestamp)
+
+
+ACTIVATIONTOKEN = AccountActivationToken()

--- a/diary/urls.py
+++ b/diary/urls.py
@@ -4,5 +4,5 @@ from . import views
 app_name = 'diary'
 urlpatterns = [
     path('signup/', views.UserSignUp.as_view(), name='signup'),
-    path('activate/', views.ActivateAccount.as_view(), name='activate')
+    path('activate/<str:slug_field>/', views.ActivateAccount.as_view(), name='activate')
 ]


### PR DESCRIPTION
#### What does this PR do?
- Makes the activation url a one time link.

#### Description of Task to be completed?
- Once the user activates their account, the link should be rendered as already used. 

#### How should this be manually tested?
1. Create a new account.
2. Check your email for the activation url.
3. Click on the button to activate your account.
4. The second time you click this link, you will be told that the account has already been activated.

#### Any background context you want to provide?
This is a bug fix for the user signup [story](https://www.pivotaltracker.com/story/show/159561794).

#### What are the relevant pivotal tracker stories?
[Pivotal tracker story](https://www.pivotaltracker.com/story/show/159726622)
